### PR TITLE
Fixed erroneous documentation, clarified form label

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ A simple extension for [RainLab Blog](https://octobercms.com/plugin/rainlab-blog
 Awesome Categories plugin adds a few new fields to the Category model, so you could customize a look and feel for your categories even more when showing them on the frontend. New fields are:
 * `awesome_icon` (e.g. ```{{ category.awesome_icon }}```, ```{{ category.awesomeIcon }}```) - powered by [Awesome Icons List](https://octobercms.com/plugin/ginopane-awesomeiconslist), adds ability to select an icon for a category;
 * `awesome_color` (e.g. ```{{ category.awesome_color }}```, ```{{ category.awesomeColor }}```) - a color-picker field which simply adds ability to attach a color to a category, the color is stored as hex color;
-* `awesome_style` (e.g. ```{{ category.awesome_style }}```, ```{{ category.awesomeStyle }}```) - if it is not enough, a dedicated field for custom CSS style is ready for you.
+* `awesome_class` (e.g. ```{{ category.awesome_class }}```, ```{{ category.awesomeClass }}```) - if it is not enough, a dedicated field for custom CSS style is ready for you.
 
 > No components or widgets are provided by this plugin

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -15,7 +15,7 @@ return [
             'placeholder' => 'Select icon...'
         ],
         'awesome_class' => [
-            'label' => 'Custom CSS class'
+            'label' => 'Custom CSS class list (separated by spaces if more than one)'
         ],
         'awesome_color' => [
             'label' => 'Color'


### PR DESCRIPTION
The documentation is incorrect. It states the use of `awesome_style`, `awesomeStyle`, etc. It should be `awesome_class`, etc. Fixed.

Also clarified the backend form label for this field to denote that you should specify classes separated by a space.

@GinoPane
